### PR TITLE
refactor: introduce domain model layer for Job

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -231,3 +231,4 @@ pyrightconfig.json
 # Custom rules (everything added below won't be overriden by 'Generate .gitignore File' if you use 'Update' option)
 
 *.db
+TODO

--- a/app/domains/job.py
+++ b/app/domains/job.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import Enum
+from uuid import UUID, uuid4
+
+from app.db.models.job import Job as DBJob
+
+
+class InvalidJobTransitionError(Exception):
+    pass
+
+
+@dataclass
+class DataSource:
+    """Value object - no identity"""
+
+    type: str
+    uri: str
+
+    def __post_init__(self) -> None:
+        if self.type not in ("url", "upload"):
+            raise ValueError(f"Invalid source type: {self.type}")
+
+
+class JobStatus(Enum):
+    """Explicit state enumeration"""
+
+    QUEUED = "queued"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+    RETRY_SCHEDULED = "retry_scheduled"
+
+
+@dataclass
+class Job:
+    id: UUID
+    status: JobStatus
+    dataset_type: str
+    schema_version: str
+    source_type: str
+    source_uri: str
+    created_at: datetime
+
+    @classmethod
+    def create_new(
+        cls, dataset_type: str, schema_version: str, source: DataSource
+    ) -> Job:
+        return cls(
+            id=uuid4(),
+            status=JobStatus.QUEUED,
+            dataset_type=dataset_type,
+            schema_version=schema_version,
+            source_type=source.type,
+            source_uri=source.uri,
+            created_at=datetime.now(UTC),
+        )
+
+    @classmethod
+    def from_db_model(cls, db_job: DBJob) -> Job:
+        return cls(
+            id=db_job.id,
+            dataset_type=db_job.dataset_type,
+            schema_version=db_job.schema_version,
+            source_type=db_job.source_type,
+            source_uri=db_job.source_uri,
+            status=JobStatus(db_job.status),
+            created_at=db_job.created_at,
+        )
+
+    def to_db_model(self) -> DBJob:
+        return DBJob(
+            id=self.id,
+            status=self.status.value,
+            dataset_type=self.dataset_type,
+            schema_version=self.schema_version,
+            source_type=self.source_type,
+            source_uri=self.source_uri,
+            created_at=self.created_at,
+        )
+
+    def transition_to(self, new_status: JobStatus) -> None:
+        """Business rule: validate state transitions"""
+        if not self._is_valid_transition(new_status):
+            raise InvalidJobTransitionError(
+                f"Cannot transition from {self.status} to {new_status}"
+            )
+
+        self.status = new_status
+
+    def _is_valid_transition(self, new_status: JobStatus) -> bool:
+        """FSM transition rules"""
+        VALID_TRANSITIONS = {
+            JobStatus.QUEUED: {JobStatus.RUNNING, JobStatus.CANCELLED},
+            JobStatus.RUNNING: {JobStatus.SUCCEEDED, JobStatus.FAILED},
+            JobStatus.FAILED: {JobStatus.RETRY_SCHEDULED, JobStatus.CANCELLED},
+            JobStatus.RETRY_SCHEDULED: {JobStatus.QUEUED},
+            JobStatus.SUCCEEDED: set(),  # Terminal state
+            JobStatus.CANCELLED: set(),  # Terminal state
+        }
+        return new_status in VALID_TRANSITIONS[self.status]

--- a/app/repositories/job_repository.py
+++ b/app/repositories/job_repository.py
@@ -3,7 +3,8 @@ from uuid import UUID
 
 from sqlalchemy.orm import Session
 
-from app.db.models.job import Job
+from app.db.models.job import Job as DBJob
+from app.domains.job import Job
 
 
 class AbstractJobRepository(ABC):
@@ -21,10 +22,12 @@ class SqlAlchemyJobRepository(AbstractJobRepository):
         self._session = session
 
     def create(self, job: Job) -> Job:
-        self._session.add(job)
+        db_job = Job.to_db_model(job)
+        self._session.add(db_job)
         self._session.commit()
-        self._session.refresh(job)
-        return job
+        self._session.refresh(db_job)
+        return Job.from_db_model(db_job)
 
     def get_by_id(self, job_id: UUID) -> Job | None:
-        return self._session.get(Job, job_id)
+        db_job = self._session.get(DBJob, job_id)
+        return None if db_job is None else Job.from_db_model(db_job)

--- a/app/services/job_service.py
+++ b/app/services/job_service.py
@@ -1,4 +1,4 @@
-from app.db.models.job import Job
+from app.domains.job import DataSource, Job
 from app.repositories.job_repository import AbstractJobRepository
 from app.schemas.job import JobCreate
 
@@ -8,11 +8,14 @@ class JobService:
         self._repo = repo
 
     def create_job(self, payload: JobCreate) -> Job:
-        job = Job(
+
+        data_source = DataSource(
+            type=payload.source_type,
+            uri=payload.source_uri,
+        )
+        in_job = Job.create_new(
             dataset_type=payload.dataset_type,
             schema_version=payload.schema_version,
-            source_type=payload.source_type,
-            source_uri=payload.source_uri,
-            status="queued",
+            source=data_source,
         )
-        return self._repo.create(job)
+        return self._repo.create(in_job)

--- a/docs/domains.md
+++ b/docs/domains.md
@@ -1,0 +1,163 @@
+# Domain Model - Data Intake Service
+
+This document captures the domain knowledge, entities, boundaries, and patterns for the Data Intake and Validation Service.
+
+## Core Domains Identified
+
+### 1. Job Management Domain (Core Aggregate)
+
+**Purpose:** Orchestrate validation workflows through explicit state transitions
+
+**Key Entities:**
+- **Job** (Aggregate Root)
+  - Identity: `job_id`
+  - Lifecycle: `queued → running → succeeded/failed → [retry_scheduled] → cancelled`
+  - Properties: `dataset_type`, `schema_version`, `source`, `submitted_by`, `idempotency_key`
+  - Temporal: `created_at`, `started_at`, `finished_at`
+  - Resilience: `retry_count`, `error_code`, `error_message`
+
+**Invariants:**
+- State transitions must be validated (no arbitrary jumps)
+- `finished_at` must be >= `started_at` >= `created_at`
+- Idempotency keys prevent duplicate job creation
+- Retry only allowed from `failed` state
+
+**Domain Events:**
+- `JobSubmitted`, `JobStarted`, `JobSucceeded`, `JobFailed`, `JobRetryScheduled`, `JobCancelled`
+
+### 2. Validation Domain
+
+**Purpose:** Enforce data quality through multi-phase validation pipeline
+
+**Validation Phases (Order Matters):**
+1. **Source Accessibility** - can we reach the data?
+2. **Format Check** - is it parseable (CSV/JSONL/Parquet)?
+3. **Schema Conformance** - required columns present?
+4. **Type Coercion** - can values be cast to expected types?
+5. **Business Rules** - row-level constraints (nullability, value ranges, cross-field)
+6. **Aggregate Checks** - uniqueness constraints, cardinality rules
+
+**Key Entities:**
+- **ValidationResult** (Value Object)
+  - Metrics: `total_rows`, `valid_rows`, `invalid_rows`
+  - Summary: `summary_json` (detailed error breakdown)
+  - Artifact: `artifact_uri` (points to detailed report)
+
+**Business Rules Examples:**
+- `student_id` non-null
+- `enrollment_date <= withdrawal_date`
+- `grade_level` in allowed values
+- No duplicate `(student_id, school_id, effective_date)` composite keys
+
+### 3. Schema Registry Domain
+
+**Purpose:** Version-controlled data contracts as first-class entities
+
+**Key Entities:**
+- **DatasetSchema** (Aggregate Root)
+  - Identity: `(dataset_type, version)` composite key
+  - Definition: `definition_json` (column specs, types, rules)
+  - Lifecycle: `is_active` flag
+  - Temporal: `created_at`
+
+**Concepts:**
+- Schemas are **versioned** - `student_enrollment:v1`, `student_enrollment:v2`
+- Only one version can be `is_active=true` per dataset type (or multiple active versions allowed?)
+- Schema evolution: new versions don't break existing jobs
+
+**Invariants:**
+- Version strings must be immutable once created
+- Definition changes require new version
+- Cannot delete schemas referenced by existing jobs
+
+### 4. Data Source Domain
+
+**Purpose:** Abstract different ingestion mechanisms
+
+**Source Types:**
+- **URL Pull** - `{"type": "url", "uri": "https://..."}`
+- **File Upload** - direct upload (binary data in request)
+- Future: S3/GCS paths, streaming sources
+
+**Responsibilities:**
+- Retrieve data from source
+- Handle transient failures (retry with backoff)
+- Support large files (streaming)
+
+### 5. Idempotency Domain (Cross-cutting)
+
+**Purpose:** Prevent duplicate processing from retries
+
+**Key Concepts:**
+- `idempotency_key` in submission = client-controlled deduplication
+- Check existing jobs before creating new one
+- Return existing job if key matches
+- Keys must be unique + contextual (likely scoped to user/tenant)
+
+**Critical for:**
+- Webhook retries
+- Pipeline reruns
+- Client-side retry logic
+- Network failure recovery
+
+---
+
+## Domain Relationships
+
+```
+Job (1) ←→ (1) ValidationResult
+Job (N) → (1) DatasetSchema [via dataset_type + schema_version]
+Job (1) → (1) DataSource [composition]
+Job (1) ← (N) JobEvent [optional audit trail]
+```
+
+---
+
+## Bounded Contexts
+
+**API Context:**
+- Translates HTTP requests to domain commands
+- Owns request/response schemas
+- Exception → HTTP status mapping
+- Never imports from workers
+
+**Worker Context:**
+- Executes async validation jobs
+- Owns background job infrastructure
+- Never imports from API
+
+**Shared Kernel:**
+- Services layer (business logic)
+- Repositories (data access)
+- DB models (persistence)
+- Core utilities (config, logging, exceptions)
+
+---
+
+## Key Domain Patterns
+
+**State Machine:** Jobs follow explicit FSM, transitions validated
+
+**Event Sourcing (Optional):** `job_events` table for audit trail
+
+**Repository Pattern:** Abstract persistence from business logic
+
+**Value Objects:** `ValidationResult`, `DataSource` (no identity, compared by value)
+
+**Aggregate Roots:** `Job`, `DatasetSchema` (consistency boundaries)
+
+**Idempotent Operations:** Submission, retry (using idempotency keys)
+
+---
+
+## What This Teaches You
+
+This domain model naturally forces:
+- **Workflow state management** (FSM)
+- **Data contracts** (versioned schemas)
+- **Boundary validation** (multi-phase validation)
+- **Resilience patterns** (idempotency, retries)
+- **Async workflows** (job submission ≠ job execution)
+- **Domain events** (state transition tracking)
+
+The complexity is real but not overwhelming - perfect senior-level scope.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Data Intake Service"
 requires-python = ">=3.13"
 dependencies = [
-    "fastapi>=0.115,<1",
+    "fastapi[standard]>=0.115,<1",
     "uvicorn[standard]>=0.34,<1",
     "sqlalchemy>=2.0,<3",
     "alembic>=1.14,<2",

--- a/tests/factories/job_factory.py
+++ b/tests/factories/job_factory.py
@@ -1,20 +1,22 @@
 from typing import Any
 
-from app.db.models.job import Job
+from app.domains.job import DataSource, Job
 from app.schemas.job import JobCreate
 
-DEFAULTS = {
+DEFAULTS: dict[str, Any] = {
     "dataset_type": "test",
     "schema_version": "v1",
     "source_type": "url",
     "source_uri": "https://example.com/data.csv",
-    "status": "queued",
 }
 
 
-def job_factory(**overrides: Any):
+def job_factory(**overrides: Any) -> Job:
     """Factory for creating Job instances with sensible defaults."""
-    return Job(**(DEFAULTS | overrides))
+    params = DEFAULTS | overrides
+    data_source = DataSource(params.pop("source_type"), params.pop("source_uri"))
+    params["source"] = data_source
+    return Job.create_new(**params)
 
 
 def job_create_factory(**overrides: Any):

--- a/tests/fakes/fake_job_repository.py
+++ b/tests/fakes/fake_job_repository.py
@@ -1,6 +1,6 @@
-from uuid import UUID, uuid4
+from uuid import UUID
 
-from app.db.models.job import Job
+from app.domains.job import Job
 from app.repositories.job_repository import AbstractJobRepository
 
 
@@ -9,7 +9,6 @@ class FakeJobRepository(AbstractJobRepository):
         self._jobs: dict[UUID, Job] = {}
 
     def create(self, job: Job) -> Job:
-        job.id = uuid4()
         self._jobs[job.id] = job
         return job
 

--- a/tests/unit/services/test_job_service.py
+++ b/tests/unit/services/test_job_service.py
@@ -1,3 +1,4 @@
+from app.domains.job import JobStatus
 from app.schemas.job import JobCreate
 from app.services.job_service import JobService
 from tests.factories.job_factory import DEFAULTS
@@ -11,12 +12,12 @@ def test_job_service_create_job(
     job = service.create_job(job_create)
 
     assert job.id is not None
+    assert job.status == JobStatus.QUEUED
     attr_list = [
         "dataset_type",
         "schema_version",
         "source_type",
         "source_uri",
-        "status",
     ]
     for field in attr_list:
         assert getattr(job, field) == DEFAULTS.get(field)


### PR DESCRIPTION
## Summary
Introduces a domain-driven design (DDD) layer with rich domain models separate from database persistence models. This refactoring separates business logic from database concerns and enables explicit state transition validation.

## Changes
- Add `app/domains/` package with Job domain model
- Add DataSource value object for type-safe source handling
- Add JobStatus enum for explicit state representation
- Add state transition validation with `transition_to()` method
- Refactor JobService to use domain model instead of DB model directly
- Update SqlAlchemyJobRepository to convert between domain and DB models
- Update tests to use domain model and JobStatus enum
- Add comprehensive DDD documentation in docs/domains.md
- Add fastapi[standard] dependency for enhanced FastAPI features

## Testing
- [x] All existing tests pass with domain model
- [x] Unit tests updated to use JobStatus enum
- [x] Type checking passes (mypy strict mode)
- [x] Pre-commit hooks pass (ruff, formatting)
- [x] State transition validation works correctly

## Related
Architectural improvement - no related issues
