### PR TITLE
feat(config): add Docker and VS Code devcontainer support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,56 @@
+{
+  "name": "Data Intake Service",
+  "dockerComposeFile": "../docker-compose.yml",
+  "service": "web",
+  "workspaceFolder": "/app",
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "charliermarsh.ruff",
+        "ms-python.mypy-type-checker",
+        "tamasfe.even-better-toml",
+        "anthropic.claude-code"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "/usr/local/bin/python",
+        "python.linting.enabled": true,
+        "python.linting.mypyEnabled": true,
+        "python.formatting.provider": "none",
+        "[python]": {
+          "editor.defaultFormatter": "charliermarsh.ruff",
+          "editor.formatOnSave": true,
+          "editor.codeActionsOnSave": {
+            "source.fixAll": "explicit",
+            "source.organizeImports": "explicit"
+          }
+        },
+        "ruff.importStrategy": "fromEnvironment"
+      }
+    }
+  },
+
+  "forwardPorts": [8000, 5432],
+  "portsAttributes": {
+    "8000": {
+      "label": "FastAPI",
+      "onAutoForward": "notify"
+    },
+    "5432": {
+      "label": "PostgreSQL",
+      "onAutoForward": "silent"
+    }
+  },
+
+  "postCreateCommand": "bash .devcontainer/setup-ssh.sh && echo 'Dev container ready!'",
+
+  "remoteUser": "root",
+
+  "mounts": [
+    "source=${localEnv:HOME}/.ssh,target=/root/.ssh,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.claude,target=/root/.claude,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.aws,target=/root/.aws,type=bind,consistency=cached"
+  ]
+}

--- a/.devcontainer/setup-ssh.sh
+++ b/.devcontainer/setup-ssh.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Fix SSH configuration for Linux container (strip macOS-specific options)
+
+# Set correct permissions on SSH keys
+chmod 600 /root/.ssh/id_ed25519* 2>/dev/null || true
+
+# Remove macOS-specific SSH options that don't exist in Linux
+sed -i '/UseKeychain/d' /root/.ssh/config 2>/dev/null || true
+sed -i '/AddKeysToAgent/d' /root/.ssh/config 2>/dev/null || true
+
+echo "SSH configuration fixed for container"

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.venv/
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.pytest_cache/
+.coverage
+.mypy_cache/
+.ruff_cache/
+.git/
+.github/
+*.db
+*.db-journal
+.env
+.env.local
+*.md
+!docker-entrypoint.sh

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# PostgreSQL Configuration
+POSTGRES_DB=data_intake
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+
+# Application Configuration
+ENV=local
+LOG_LEVEL=INFO
+DATABASE_URL=postgresql://postgres:postgres@db:5432/data_intake

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM python:3.13-slim
+
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libpq-dev gcc \
+    git \
+    openssh-client \
+    postgresql-client \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy pyproject.toml for dependency installation
+COPY pyproject.toml .
+
+# Install Python dependencies
+RUN pip install --no-cache-dir -e ".[dev]"
+
+# Source code will be mounted as volume, not copied
+
+# Expose port
+EXPOSE 8000
+
+# Entrypoint script
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,22 @@ A FastAPI service that accepts dataset uploads or pull requests, validates them
 against declared schemas and business rules, stores results, and exposes job
 status and validation reports through an API.
 
+## Table of Contents
+
+- [Job Lifecycle](#job-lifecycle)
+- [Project Structure](#project-structure)
+- [Docker Setup (Recommended)](#docker-setup-recommended)
+  - [VS Code Devcontainer](#vs-code-devcontainer-recommended-for-vs-code-users)
+  - [Quick Start](#quick-start-without-devcontainer)
+  - [Common Docker Commands](#common-docker-commands)
+  - [Development Workflow](#development-workflow)
+- [Native Setup (Alternative)](#native-setup-alternative)
+- [Development](#development)
+  - [Running Tests](#running-tests)
+  - [Code Quality Checks](#code-quality-checks)
+  - [Commit Message Convention](#commit-message-convention)
+  - [CI/CD](#cicd)
+
 ## Job Lifecycle
 
 Jobs follow an explicit state machine. Transitions are validated — arbitrary
@@ -87,7 +103,99 @@ workers/ ─┘
 Services, repositories, and database code must never import from `api/` or
 `workers/`.
 
-## Getting Started
+## Docker Setup (Recommended)
+
+The fastest way to get started is using Docker Compose, which runs the FastAPI app and PostgreSQL together.
+
+### Prerequisites
+- Docker and Docker Compose installed
+- (Optional) VS Code for devcontainer support
+
+### VS Code Devcontainer (Recommended for VS Code users)
+
+If you're using VS Code, you can develop inside the container with full IDE integration:
+
+1. Install the "Dev Containers" extension in VS Code
+2. Copy the example environment file:
+   ```bash
+   cp .env.example .env
+   ```
+3. Open the project in VS Code
+4. Click "Reopen in Container" when prompted (or run "Dev Containers: Reopen in Container" from the command palette)
+5. VS Code will build and start the containers, then connect you to the development environment
+6. Your terminal, debugger, and IntelliSense will all run inside the container
+
+With devcontainer:
+- No need for `docker-compose exec` - your terminal is already inside the container
+- Run commands directly: `pytest`, `alembic upgrade head`, `uvicorn app.main:app --reload`
+- Debug FastAPI directly with VS Code breakpoints
+- Extensions (Ruff, mypy, Python) install automatically
+
+**Git configuration:**
+Git user configuration is set at the repository level (not mounted from host). After cloning, set your git identity:
+
+```bash
+git config user.name "Your Name"
+git config user.email "your.email@example.com"
+```
+
+The devcontainer automatically strips macOS-specific SSH options (`UseKeychain`, `AddKeysToAgent`) from your mounted SSH config to ensure compatibility with Linux.
+
+### Quick Start (without devcontainer)
+
+1. Copy the example environment file:
+   ```bash
+   cp .env.example .env
+   ```
+
+2. Start the services:
+   ```bash
+   docker-compose up
+   ```
+
+3. The API will be available at `http://localhost:8000`
+4. PostgreSQL will be available at `localhost:5432`
+
+### Common Docker Commands
+
+```bash
+# Start services in background
+docker-compose up -d
+
+# View logs
+docker-compose logs -f
+
+# Stop services (preserves data)
+docker-compose down
+
+# Stop services and remove volumes (fresh start)
+docker-compose down -v
+
+# Rebuild after dependency changes
+docker-compose up --build
+
+# Run tests
+docker-compose exec web pytest
+
+# Create a migration
+docker-compose exec web alembic revision --autogenerate -m "description"
+
+# Access PostgreSQL directly
+docker-compose exec db psql -U postgres -d data_intake
+
+# Run any command in the web container
+docker-compose exec web <command>
+```
+
+### Development Workflow
+
+- Edit code on your host machine
+- Changes are automatically reflected (hot reload enabled)
+- PostgreSQL data persists in a Docker volume across restarts
+
+## Native Setup (Alternative)
+
+If you prefer to run without Docker, you can use a Python virtual environment. You'll need to install and configure PostgreSQL manually.
 
 ```bash
 # Create and activate a virtual environment (Python 3.13+ required)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,42 @@
+version: '3.8'
+
+services:
+  db:
+    image: postgres:16-alpine
+    container_name: data-intake-db
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-data_intake}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  web:
+    build: .
+    container_name: data-intake-web
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@db:5432/${POSTGRES_DB:-data_intake}
+      ENV: ${ENV:-local}
+      LOG_LEVEL: ${LOG_LEVEL:-INFO}
+      POSTGRES_HOST: db
+      POSTGRES_DB: ${POSTGRES_DB:-data_intake}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+    ports:
+      - "8000:8000"
+    volumes:
+      - .:/app
+      - /app/.venv  # Prevent mounting host's venv
+    depends_on:
+      db:
+        condition: service_healthy
+
+volumes:
+  postgres_data:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+echo "Waiting for PostgreSQL to be ready..."
+until PGPASSWORD=$POSTGRES_PASSWORD psql -h "$POSTGRES_HOST" -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c '\q' 2>/dev/null; do
+  echo "PostgreSQL is unavailable - sleeping"
+  sleep 1
+done
+
+echo "PostgreSQL is up - running migrations"
+alembic upgrade head
+
+echo "Starting uvicorn..."
+exec uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "httpx>=0.28,<1",
     "python-json-logger>=2.0,<3",
     "pyyaml>=6.0,<7",
+    "psycopg2-binary>=2.9,<3",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
Adds complete Docker Compose setup for local development with PostgreSQL, replacing SQLite. Includes VS Code devcontainer configuration for full IDE integration with hot reload, debugging, and automatic extension installation.

## Changes
- Add Dockerfile with Python 3.13, PostgreSQL client, git, and SSH support
- Add docker-compose.yml with web and db services (PostgreSQL 16)
- Add VS Code devcontainer configuration with credential mounts (.ssh, .claude, .aws)
- Add SSH setup script to strip macOS-specific options for Linux compatibility
- Add .env.example for environment configuration
- Add psycopg2-binary dependency for PostgreSQL connectivity
- Update README with comprehensive Docker setup documentation and table of contents
- Add .dockerignore to optimize build context

## Testing
- [x] Docker Compose builds and starts successfully
- [x] PostgreSQL database initializes and accepts connections
- [x] Hot reload works for code changes
- [x] Devcontainer opens and mounts credentials correctly
- [x] Git operations work inside devcontainer with SSH
- [x] Claude Code extension works with AWS Bedrock
- [x] Database migrations run automatically on container startup

## Related
Addresses TODO items: "Dockerize for local dev" and "Add postgres"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
