### PR TITLE
feat(workers): implement Phase 4 background job processing with RQ

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,15 +3,26 @@ POSTGRES_DB=data_intake
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
 
+# Redis Configuration
+REDIS_PASSWORD=redis
+
 # Application Configuration
 ENV=local
 LOG_LEVEL=INFO
 
 # Database URL for the running application
 # Options:
-#   - PostgreSQL: postgresql://postgres:postgres@db:5432/data_intake (default, recommended)
-#   - SQLite:     sqlite:///./data_intake.db (for development without Docker, including Alembic migrations)
+#   - Docker (PostgreSQL): postgresql://postgres:postgres@db:5432/data_intake
+#   - Local (PostgreSQL):  postgresql://postgres:postgres@localhost:5432/data_intake
+#   - Local (SQLite):      sqlite:///./data_intake.db (for development without Postgres)
 DATABASE_URL=postgresql://postgres:postgres@db:5432/data_intake
+
+# Redis URL for job queue (RQ)
+# Format: redis://[user]:[password]@[host]:[port]/[database]
+# Options:
+#   - Docker: redis://default:redis@redis:6379/0 (uses service name 'redis')
+#   - Local:  redis://default:redis@localhost:6379/0 (uses localhost)
+REDIS_URL=redis://default:redis@redis:6379/0
 
 # Test Database URL (optional)
 # If not set, tests default to sqlite:///:memory: for speed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,16 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,7 @@ jobs:
       - name: Run tests with coverage
         env:
           ENV: test
+          DATABASE_URL: postgresql://test_user:test_password@localhost:5432/test_db
           TEST_DATABASE_URL: postgresql://test_user:test_password@localhost:5432/test_db
         run: |
           pytest tests/ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,9 @@ RUN pip install --no-cache-dir -e ".[dev]"
 # Expose port
 EXPOSE 8000
 
-# Entrypoint script
+# Entrypoint scripts
 COPY docker-entrypoint.sh /docker-entrypoint.sh
-RUN chmod +x /docker-entrypoint.sh
+COPY docker-entrypoint-worker.sh /docker-entrypoint-worker.sh
+RUN chmod +x /docker-entrypoint.sh /docker-entrypoint-worker.sh
 
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -21,6 +21,7 @@ class Settings(BaseSettings):
     ENV: Environment = Environment.LOCAL
     DEBUG: bool = False
     DATABASE_URL: str = "sqlite:///./data_intake.db"
+    REDIS_URL: str = "redis://default:redis@localhost:6379/0"
     LOG_LEVEL: str = "INFO"
     MAX_JOB_RETRIES: int = 3
 

--- a/app/services/job_service.py
+++ b/app/services/job_service.py
@@ -83,6 +83,13 @@ class JobService:
         )
         job = self._repo.create(in_job)
         logger.info("job created successfully")
+
+        # Lazy import to avoid initializing Redis at module import time
+        from app.workers.queue import queue
+        from app.workers.tasks import execute_validation_job
+
+        logger.info("job queued")
+        queue.enqueue(execute_validation_job, job.id)
         return job
 
     def get_job_by_id(self, job_id: UUID) -> Job:

--- a/app/services/job_service.py
+++ b/app/services/job_service.py
@@ -85,12 +85,14 @@ class JobService:
         logger.info("job created successfully")
 
         # Enqueue job for background processing (lazy initialization)
+        # Note: If enqueue fails after DB commit, job will exist in QUEUED state
+        # but won't be in Redis queue. Future phases can add monitoring/recovery.
         from app.workers.queue import get_queue
         from app.workers.tasks import execute_validation_job
 
-        logger.info("job queued")
         queue = get_queue()
         queue.enqueue(execute_validation_job, job.id)
+        logger.info("job queued")
         return job
 
     def get_job_by_id(self, job_id: UUID) -> Job:

--- a/app/services/job_service.py
+++ b/app/services/job_service.py
@@ -84,11 +84,12 @@ class JobService:
         job = self._repo.create(in_job)
         logger.info("job created successfully")
 
-        # Lazy import to avoid initializing Redis at module import time
-        from app.workers.queue import queue
+        # Enqueue job for background processing (lazy initialization)
+        from app.workers.queue import get_queue
         from app.workers.tasks import execute_validation_job
 
         logger.info("job queued")
+        queue = get_queue()
         queue.enqueue(execute_validation_job, job.id)
         return job
 

--- a/app/workers/queue.py
+++ b/app/workers/queue.py
@@ -1,0 +1,46 @@
+"""RQ queue initialization for background job processing."""
+
+import logging
+
+from redis import Redis, RedisError
+from rq import Queue
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+def _init_redis() -> Redis:
+    """Initialize Redis connection with error handling."""
+    try:
+        # Parse REDIS_URL from settings
+        # Format: redis://[:password@]host:port/db
+        redis_conn = Redis.from_url(
+            settings.REDIS_URL,
+            decode_responses=False,  # RQ expects bytes
+            socket_connect_timeout=5,
+            socket_timeout=5,
+        )
+
+        # Test connection
+        redis_conn.ping()
+        logger.info(
+            "Redis connection established: %s",
+            settings.REDIS_URL.split("@")[-1],  # Don't log password
+        )
+        return redis_conn
+
+    except RedisError as e:
+        logger.error("Redis connection failed: %s", str(e))
+        raise
+
+
+# Initialize Redis connection and queue
+redis_conn = _init_redis()
+queue = Queue(
+    name="default",
+    connection=redis_conn,
+    default_timeout=600,
+)
+
+logger.info("RQ queue initialized: %s", queue.name)

--- a/app/workers/queue.py
+++ b/app/workers/queue.py
@@ -9,6 +9,10 @@ from app.core.config import settings
 
 logger = logging.getLogger(__name__)
 
+# Lazy-initialized global queue
+_queue: Queue | None = None
+_redis_conn: Redis | None = None
+
 
 def _init_redis() -> Redis:
     """Initialize Redis connection with error handling."""
@@ -35,12 +39,17 @@ def _init_redis() -> Redis:
         raise
 
 
-# Initialize Redis connection and queue
-redis_conn = _init_redis()
-queue = Queue(
-    name="default",
-    connection=redis_conn,
-    default_timeout=600,
-)
+def get_queue() -> Queue:
+    """Get or initialize the RQ queue (lazy initialization)."""
+    global _queue, _redis_conn
 
-logger.info("RQ queue initialized: %s", queue.name)
+    if _queue is None:
+        _redis_conn = _init_redis()
+        _queue = Queue(
+            name="default",
+            connection=_redis_conn,
+            default_timeout=600,
+        )
+        logger.info("RQ queue initialized: %s", _queue.name)
+
+    return _queue

--- a/app/workers/queue.py
+++ b/app/workers/queue.py
@@ -40,7 +40,18 @@ def _init_redis() -> Redis:
 
 
 def get_queue() -> Queue:
-    """Get or initialize the RQ queue (lazy initialization)."""
+    """Get or initialize the RQ queue (lazy initialization).
+
+    Uses lazy initialization to avoid Redis connection attempts during
+    test collection/import. The queue is created on first access and
+    reused for subsequent calls.
+
+    Returns:
+        Queue: The initialized RQ queue instance.
+
+    Raises:
+        RedisError: If Redis connection fails.
+    """
     global _queue, _redis_conn
 
     if _queue is None:

--- a/app/workers/tasks.py
+++ b/app/workers/tasks.py
@@ -32,7 +32,9 @@ def execute_validation_job(job_id: UUID) -> None:
         service.complete_job(job_id)
 
     except Exception as e:
-        # Log and mark as failed (only if service was successfully created)
+        # Only mark job as failed if service was successfully created.
+        # If repo/service instantiation failed, we can't access the database
+        # to update the job status, so we just re-raise the exception.
         if service is not None:
             fail_payload = JobFail(
                 error_code="WORKER_ERROR",

--- a/app/workers/tasks.py
+++ b/app/workers/tasks.py
@@ -1,0 +1,44 @@
+from time import sleep
+from uuid import UUID
+
+from app.core.logging.context import set_job_id
+from app.db.session import SessionLocal
+from app.repositories.job_repository import SqlAlchemyJobRepository
+from app.schemas.job import JobFail
+from app.services.job_service import JobService
+
+
+def execute_validation_job(job_id: UUID) -> None:
+    """Worker task to execute validation job (Phase 4: mock validation)."""
+
+    # Manual dependency instantiation (standard RQ pattern)
+    db = SessionLocal()
+    service = None
+
+    try:
+        repo = SqlAlchemyJobRepository(db)
+        service = JobService(repo)
+
+        # Set logging context
+        set_job_id(job_id)
+
+        # Start job
+        service.start_job(job_id)
+
+        # Mock validation (replace in Phase 5)
+        sleep(3)  # Simulate work
+
+        # Complete job
+        service.complete_job(job_id)
+
+    except Exception as e:
+        # Log and mark as failed (only if service was successfully created)
+        if service is not None:
+            fail_payload = JobFail(
+                error_code="WORKER_ERROR",
+                error_message=str(e)[:500],  # Truncate to max length
+            )
+            service.fail_job(fail_payload, job_id)
+        raise  # Re-raise for RQ retry handling (Phase 6)
+    finally:
+        db.close()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,11 +18,31 @@ services:
       timeout: 5s
       retries: 5
 
+  redis:
+    image: redis:7-alpine
+    container_name: data-intake-redis
+    ports:
+        - '6379:6379'
+    volumes:
+        - redis-data:/data
+    command: >
+      redis-server
+      --requirepass ${REDIS_PASSWORD:-redis}
+      --appendonly yes
+      --appendfsync everysec
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD:-redis}", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+    restart: unless-stopped
+
   web:
     build: .
     container_name: data-intake-web
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@db:5432/${POSTGRES_DB:-data_intake}
+      REDIS_URL: redis://default:${REDIS_PASSWORD:-redis}@redis:6379/0
       ENV: ${ENV:-local}
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
       POSTGRES_HOST: db
@@ -37,6 +57,29 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      redis:
+        condition: service_healthy
+
+  worker:
+    build: .
+    container_name: data-intake-worker
+    entrypoint: ["/docker-entrypoint-worker.sh"]
+    command: rq worker --url redis://default:${REDIS_PASSWORD:-redis}@redis:6379/0 default
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@db:5432/${POSTGRES_DB:-data_intake}
+      REDIS_URL: redis://default:${REDIS_PASSWORD:-redis}@redis:6379/0
+      ENV: ${ENV:-local}
+      LOG_LEVEL: ${LOG_LEVEL:-INFO}
+    volumes:
+      - .:/app
+      - /app/.venv  # Prevent mounting host's venv
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
 
 volumes:
   postgres_data:
+  redis-data:

--- a/docker-entrypoint-worker.sh
+++ b/docker-entrypoint-worker.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+echo "Starting RQ worker..."
+exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -11,4 +11,4 @@ echo "PostgreSQL is up - running migrations"
 alembic upgrade head
 
 echo "Starting uvicorn..."
-exec uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+exec uvicorn app.main:app --host 0.0.0.0 --port 8000

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ exclude = ["tests*", "alembic*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+pythonpath = ["."]
 asyncio_mode = "auto"
 addopts = ["--strict-markers", "--strict-config", "-ra"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "python-json-logger>=2.0,<3",
     "pyyaml>=6.0,<7",
     "psycopg2-binary>=2.9,<3",
+    "rq>=2.8,<3"
 ]
 
 [project.optional-dependencies]
@@ -109,5 +110,5 @@ strict_equality = true
 disallow_untyped_calls = false
 
 [[tool.mypy.overrides]]
-module = ["alembic.*", "sqlalchemy.*", "yaml"]
+module = ["alembic.*", "sqlalchemy.*", "yaml", "redis", "rq"]
 ignore_missing_imports = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,8 +100,16 @@ def db_session(db_engine: Engine) -> Generator[Session]:
 
 
 @pytest.fixture(autouse=True)
-def mock_redis_queue() -> Generator[MagicMock]:
-    """Mock Redis queue for all tests to avoid Redis dependency."""
+def mock_redis_queue(request: pytest.FixtureRequest) -> Generator[MagicMock | None]:
+    """Mock Redis queue for all tests to avoid Redis dependency.
+
+    Skips mocking for integration worker tests that need real Redis.
+    """
+    # Don't mock for integration worker tests - they use real Redis
+    if "test_job_worker" in request.node.nodeid:
+        yield None
+        return
+
     with patch("app.workers.queue.get_queue") as mock_get_queue:
         mock_queue = MagicMock()
         mock_get_queue.return_value = mock_queue

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import os
 from collections.abc import Callable, Generator
 from typing import Any
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -96,6 +97,15 @@ def db_session(db_engine: Engine) -> Generator[Session]:
             session.execute(table.delete())
         session.commit()
         session.close()
+
+
+@pytest.fixture(autouse=True)
+def mock_redis_queue() -> Generator[MagicMock]:
+    """Mock Redis queue for all tests to avoid Redis dependency."""
+    with patch("app.workers.queue.get_queue") as mock_get_queue:
+        mock_queue = MagicMock()
+        mock_get_queue.return_value = mock_queue
+        yield mock_queue
 
 
 @pytest.fixture

--- a/tests/integration/workers/test_job_worker.py
+++ b/tests/integration/workers/test_job_worker.py
@@ -1,0 +1,268 @@
+"""Integration tests for worker job processing.
+
+NOTE: These tests require a real database (not SQLite in-memory) because the worker
+runs in a separate session and needs to see committed data. Set TEST_DATABASE_URL
+to use PostgreSQL or SQLite file database:
+
+    TEST_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/data_intake pytest
+    TEST_DATABASE_URL=sqlite:///./test_worker.db pytest
+
+These tests also require Redis to be running on localhost:6379.
+"""
+
+import os
+from unittest.mock import patch
+from uuid import UUID, uuid4
+
+import pytest
+from redis import Redis, RedisError
+from rq import Queue, SimpleWorker
+from sqlalchemy.orm import Session
+
+from app.domains.job import JobStatus
+from app.repositories.job_repository import SqlAlchemyJobRepository
+from app.schemas.job import JobCreate
+from app.services.job_service import JobService
+from app.workers.tasks import execute_validation_job
+
+# Skip all tests in this module if using in-memory database or no Redis
+_TEST_DB_URL = os.getenv("TEST_DATABASE_URL", "sqlite:///:memory:")
+_SKIP_REASON = (
+    "Worker integration tests require a real database (not in-memory SQLite). "
+    "Set TEST_DATABASE_URL to postgresql://... or sqlite:///file.db"
+)
+
+pytestmark = pytest.mark.skipif(
+    _TEST_DB_URL == "sqlite:///:memory:",
+    reason=_SKIP_REASON,
+)
+
+
+@pytest.fixture
+def redis_conn():
+    """Create Redis connection for tests."""
+    # Use DB 1 for tests to avoid conflicts with development
+    # Local Redis typically has no password, Docker Redis has password
+    try:
+        redis = Redis(host="localhost", port=6379, db=1, decode_responses=True)
+        redis.ping()  # type: ignore[no-untyped-call]
+    except Exception:
+        try:
+            # If that fails, it might be in Docker with password
+            redis = Redis(
+                host="localhost",
+                port=6379,
+                db=1,
+                password="redis",
+                decode_responses=True,
+            )
+            redis.ping()  # type: ignore[no-untyped-call]
+        except (RedisError, Exception) as e:
+            pytest.skip(f"Redis not available: {e}")
+    redis.flushdb()  # type: ignore[no-untyped-call]
+    yield redis
+    redis.flushdb()  # type: ignore[no-untyped-call]
+    redis.close()
+
+
+@pytest.fixture
+def test_queue(redis_conn: Redis):
+    """Create test queue."""
+    return Queue("test", connection=redis_conn, is_async=False)
+
+
+class TestJobWorkerIntegration:
+    """Integration tests for worker processing jobs end-to-end."""
+
+    @patch("app.workers.tasks.sleep")  # Mock sleep to speed up tests
+    def test_worker_processes_job_successfully(
+        self,
+        mock_sleep,  # type: ignore[misc]
+        db_session: Session,
+        redis_conn: Redis,
+        test_queue: Queue,
+    ):
+        """Test that worker picks up job and processes it through to completion."""
+        # Arrange
+        repo = SqlAlchemyJobRepository(db_session)
+        service = JobService(repo)
+
+        # Create a job in the database
+        job_create = JobCreate(
+            dataset_type="test_data",
+            schema_version="1.0",
+            source_type="url",
+            source_uri="https://example.com/test.csv",
+        )
+        job = service.create_job(job_create)
+
+        # Commit so worker can see the job in its own session
+        db_session.commit()
+
+        assert job.status == JobStatus.QUEUED
+
+        # Enqueue the job manually (bypass service.create_job's enqueue)
+        test_queue.enqueue(execute_validation_job, job.id)  # type: ignore[call-arg]
+
+        # Act - Process the queue synchronously
+        worker = SimpleWorker([test_queue], connection=redis_conn)
+        worker.work(burst=True, max_jobs=1)
+
+        # Assert - Verify job transitioned through states
+        db_session.expire_all()  # Refresh from database
+        completed_job = repo.get_by_id(job.id)
+
+        assert completed_job is not None
+        assert completed_job.status == JobStatus.SUCCEEDED
+        assert completed_job.started_at is not None
+        assert completed_job.finished_at is not None
+        assert completed_job.error_code is None
+        assert completed_job.error_message is None
+
+    @patch("app.workers.tasks.sleep")
+    def test_worker_handles_job_failure(
+        self,
+        mock_sleep,  # type: ignore[misc]
+        db_session: Session,
+        redis_conn: Redis,
+        test_queue: Queue,
+    ):
+        """Test that worker handles job failures and marks job as FAILED."""
+        # Arrange
+        repo = SqlAlchemyJobRepository(db_session)
+        service = JobService(repo)
+
+        job_create = JobCreate(
+            dataset_type="test_data",
+            schema_version="1.0",
+            source_type="url",
+            source_uri="https://example.com/test.csv",
+        )
+        job = service.create_job(job_create)
+        db_session.commit()
+
+        # Make the validation fail
+        mock_sleep.side_effect = Exception("Test validation failure")
+
+        test_queue.enqueue(execute_validation_job, job.id)  # type: ignore[call-arg]
+
+        # Act - Process the queue
+        worker = SimpleWorker([test_queue], connection=redis_conn)
+        worker.work(burst=True, max_jobs=1)
+
+        # Assert - Job should be marked as FAILED
+        db_session.expire_all()
+        failed_job = repo.get_by_id(job.id)
+
+        assert failed_job is not None
+        assert failed_job.status == JobStatus.FAILED
+        assert failed_job.started_at is not None
+        assert failed_job.finished_at is not None
+        assert failed_job.error_code == "WORKER_ERROR"
+        assert (
+            failed_job.error_message
+            and "Test validation failure" in failed_job.error_message
+        )
+
+    def test_multiple_jobs_processed_sequentially(
+        self,
+        db_session: Session,
+        redis_conn: Redis,
+        test_queue: Queue,
+    ):
+        """Test that worker processes multiple jobs in order."""
+        # Arrange
+        repo = SqlAlchemyJobRepository(db_session)
+        service = JobService(repo)
+
+        # Create 3 jobs
+        job_ids: list[UUID] = []
+        for i in range(3):
+            job_create = JobCreate(
+                dataset_type=f"test_data_{i}",
+                schema_version="1.0",
+                source_type="url",
+                source_uri=f"https://example.com/test{i}.csv",
+            )
+            job = service.create_job(job_create)
+            job_ids.append(job.id)
+            test_queue.enqueue(execute_validation_job, job.id)  # type: ignore[call-arg]
+
+        db_session.commit()
+
+        # Act - Process all jobs with mocked sleep for speed
+        with patch("app.workers.tasks.sleep"):
+            worker = SimpleWorker([test_queue], connection=redis_conn)
+            worker.work(burst=True)
+
+        # Assert - All jobs completed
+        db_session.expire_all()
+        for job_id in job_ids:
+            completed_job = repo.get_by_id(job_id)
+            assert completed_job is not None
+            assert completed_job.status == JobStatus.SUCCEEDED
+
+    def test_job_transitions_through_correct_states(
+        self,
+        db_session: Session,
+        redis_conn: Redis,
+        test_queue: Queue,
+    ):
+        """Test that job transitions QUEUED → RUNNING → SUCCEEDED."""
+        # Arrange
+        repo = SqlAlchemyJobRepository(db_session)
+        service = JobService(repo)
+
+        job_create = JobCreate(
+            dataset_type="test_data",
+            schema_version="1.0",
+            source_type="url",
+            source_uri="https://example.com/test.csv",
+        )
+        job = service.create_job(job_create)
+        initial_status = job.status
+
+        db_session.commit()
+        test_queue.enqueue(execute_validation_job, job.id)  # type: ignore[call-arg]
+
+        # Act
+        with patch("app.workers.tasks.sleep"):
+            worker = SimpleWorker([test_queue], connection=redis_conn)
+            worker.work(burst=True, max_jobs=1)
+
+        # Assert state transitions
+        db_session.expire_all()
+        final_job = repo.get_by_id(job.id)
+
+        assert initial_status == JobStatus.QUEUED
+        assert final_job is not None
+        assert final_job.status == JobStatus.SUCCEEDED
+
+        # Verify timestamps are set correctly
+        assert final_job.created_at is not None
+        assert final_job.started_at is not None
+        assert final_job.finished_at is not None
+        assert final_job.created_at < final_job.started_at
+        assert final_job.started_at < final_job.finished_at
+
+    @patch("app.workers.tasks.sleep")
+    def test_worker_with_nonexistent_job_id(
+        self,
+        mock_sleep,  # type: ignore[misc]
+        db_session: Session,
+        redis_conn: Redis,
+        test_queue: Queue,
+    ):
+        """Test worker behavior when job ID doesn't exist in database."""
+        # Arrange - Enqueue a job with non-existent ID
+        fake_job_id = uuid4()
+        test_queue.enqueue(execute_validation_job, fake_job_id)  # type: ignore[call-arg]
+
+        # Act - Worker should fail when trying to fetch the job
+        worker = SimpleWorker([test_queue], connection=redis_conn)
+        worker.work(burst=True, max_jobs=1)
+
+        # Assert - Job should fail (RQ will mark it as failed)
+        # We can't verify job state in DB since it doesn't exist
+        # But we can verify the queue is empty after processing
+        assert test_queue.count == 0

--- a/tests/integration/workers/test_job_worker.py
+++ b/tests/integration/workers/test_job_worker.py
@@ -77,7 +77,7 @@ class TestJobWorkerIntegration:
     @patch("app.workers.tasks.sleep")  # Mock sleep to speed up tests
     def test_worker_processes_job_successfully(
         self,
-        mock_sleep,  # type: ignore[misc]
+        _mock_sleep,  # type: ignore[misc]
         db_session: Session,
         redis_conn: Redis,
         test_queue: Queue,
@@ -122,7 +122,7 @@ class TestJobWorkerIntegration:
     @patch("app.workers.tasks.sleep")
     def test_worker_handles_job_failure(
         self,
-        mock_sleep,  # type: ignore[misc]
+        _mock_sleep,  # type: ignore[misc]
         db_session: Session,
         redis_conn: Redis,
         test_queue: Queue,
@@ -142,7 +142,7 @@ class TestJobWorkerIntegration:
         db_session.commit()
 
         # Make the validation fail
-        mock_sleep.side_effect = Exception("Test validation failure")
+        _mock_sleep.side_effect = Exception("Test validation failure")
 
         test_queue.enqueue(execute_validation_job, job.id)  # type: ignore[call-arg]
 
@@ -248,7 +248,7 @@ class TestJobWorkerIntegration:
     @patch("app.workers.tasks.sleep")
     def test_worker_with_nonexistent_job_id(
         self,
-        mock_sleep,  # type: ignore[misc]
+        _mock_sleep,  # type: ignore[misc]
         db_session: Session,
         redis_conn: Redis,
         test_queue: Queue,

--- a/tests/unit/workers/test_tasks.py
+++ b/tests/unit/workers/test_tasks.py
@@ -1,0 +1,157 @@
+"""Unit tests for worker tasks."""
+
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.schemas.job import JobFail
+from app.workers.tasks import execute_validation_job
+
+
+class TestExecuteValidationJob:
+    """Test the execute_validation_job worker task."""
+
+    @patch("app.workers.tasks.SessionLocal")
+    @patch("app.workers.tasks.SqlAlchemyJobRepository")
+    @patch("app.workers.tasks.JobService")
+    @patch("app.workers.tasks.set_job_id")
+    @patch("app.workers.tasks.sleep")
+    def test_successful_job_execution(
+        self,
+        mock_sleep: MagicMock,
+        mock_set_job_id: MagicMock,
+        mock_job_service_class: MagicMock,
+        mock_repo_class: MagicMock,
+        mock_session_local: MagicMock,
+    ):
+        """Test successful job execution path."""
+        # Arrange
+        job_id = uuid4()
+        mock_db = MagicMock()
+        mock_session_local.return_value = mock_db
+
+        mock_repo = MagicMock()
+        mock_repo_class.return_value = mock_repo
+
+        mock_service = MagicMock()
+        mock_job_service_class.return_value = mock_service
+
+        # Act
+        execute_validation_job(job_id)
+
+        # Assert
+        mock_session_local.assert_called_once()
+        mock_repo_class.assert_called_once_with(mock_db)
+        mock_job_service_class.assert_called_once_with(mock_repo)
+        mock_set_job_id.assert_called_once_with(job_id)
+        mock_service.start_job.assert_called_once_with(job_id)
+        mock_sleep.assert_called_once_with(3)
+        mock_service.complete_job.assert_called_once_with(job_id)
+        mock_db.close.assert_called_once()
+
+    @patch("app.workers.tasks.SessionLocal")
+    @patch("app.workers.tasks.SqlAlchemyJobRepository")
+    @patch("app.workers.tasks.JobService")
+    @patch("app.workers.tasks.set_job_id")
+    @patch("app.workers.tasks.sleep")
+    def test_job_failure_during_execution(
+        self,
+        mock_sleep: MagicMock,
+        mock_set_job_id: MagicMock,
+        mock_job_service_class: MagicMock,
+        mock_repo_class: MagicMock,
+        mock_session_local: MagicMock,
+    ):
+        """Test job failure handling when work raises exception."""
+        # Arrange
+        job_id = uuid4()
+        mock_db = MagicMock()
+        mock_session_local.return_value = mock_db
+
+        mock_repo = MagicMock()
+        mock_repo_class.return_value = mock_repo
+
+        mock_service = MagicMock()
+        mock_job_service_class.return_value = mock_service
+
+        # Simulate failure during validation
+        mock_sleep.side_effect = Exception("Validation failed")
+
+        # Act & Assert
+        with pytest.raises(Exception, match="Validation failed"):
+            execute_validation_job(job_id)
+
+        # Verify fail_job was called
+        mock_service.fail_job.assert_called_once()
+        call_args = mock_service.fail_job.call_args
+        fail_payload = call_args[0][0]
+        assert isinstance(fail_payload, JobFail)
+        assert fail_payload.error_code == "WORKER_ERROR"
+        assert "Validation failed" in fail_payload.error_message
+        assert call_args[0][1] == job_id
+
+        # Verify cleanup
+        mock_db.close.assert_called_once()
+
+    @patch("app.workers.tasks.SessionLocal")
+    @patch("app.workers.tasks.SqlAlchemyJobRepository")
+    def test_failure_before_service_creation(
+        self,
+        mock_repo_class: MagicMock,
+        mock_session_local: MagicMock,
+    ):
+        """Test that service failure is handled when service is None."""
+        # Arrange
+        job_id = uuid4()
+        mock_db = MagicMock()
+        mock_session_local.return_value = mock_db
+
+        # Simulate failure during repository creation
+        mock_repo_class.side_effect = Exception("DB connection failed")
+
+        # Act & Assert
+        with pytest.raises(Exception, match="DB connection failed"):
+            execute_validation_job(job_id)
+
+        # Service was never created, so fail_job should not be called
+        # But DB should still be closed
+        mock_db.close.assert_called_once()
+
+    @patch("app.workers.tasks.SessionLocal")
+    @patch("app.workers.tasks.SqlAlchemyJobRepository")
+    @patch("app.workers.tasks.JobService")
+    @patch("app.workers.tasks.set_job_id")
+    def test_error_message_truncation(
+        self,
+        mock_set_job_id: MagicMock,
+        mock_job_service_class: MagicMock,
+        mock_repo_class: MagicMock,
+        mock_session_local: MagicMock,
+    ):
+        """Test that error messages are truncated to 500 characters."""
+        # Arrange
+        job_id = uuid4()
+        mock_db = MagicMock()
+        mock_session_local.return_value = mock_db
+
+        mock_repo = MagicMock()
+        mock_repo_class.return_value = mock_repo
+
+        mock_service = MagicMock()
+        mock_job_service_class.return_value = mock_service
+
+        # Simulate failure with very long error message
+        long_error = "x" * 600
+        test_exception = Exception(long_error)
+        mock_service.start_job.side_effect = test_exception
+
+        # Act & Assert
+        with pytest.raises(Exception, match="x+"):
+            execute_validation_job(job_id)
+
+        # Verify error message was truncated
+        mock_service.fail_job.assert_called_once()
+        fail_payload = mock_service.fail_job.call_args[0][0]
+        assert len(fail_payload.error_message) == 500
+        assert fail_payload.error_message == long_error[:500]


### PR DESCRIPTION
## Summary
- Implements Phase 4 from implementation plan: background job processing with Redis Queue (RQ)
- Jobs are automatically enqueued on creation and processed asynchronously by worker processes
- Decouples API response time from validation execution time

## Infrastructure Changes
- **Redis service**: Added to docker-compose with authentication, persistence, and health checks
- **Worker service**: New dedicated service with separate entrypoint that runs RQ worker
- **Queue module**: `app/workers/queue.py` initializes Redis connection with fail-fast pattern
- **Worker task**: `app/workers/tasks.py` implements `execute_validation_job` with proper error handling
- **Configuration**: Added `REDIS_URL` setting with authentication support
- **JobService**: Updated to automatically enqueue jobs after creation

## Testing
- **Unit tests** (4 tests): Mock all dependencies, test orchestration logic, run in 0.03s
- **Integration tests** (5 tests): Use real Redis and SimpleWorker, skip by default unless real database configured
- All tests pass with zero linting/type errors
- Tests verify: successful execution, failure handling, multiple jobs, state transitions, nonexistent job handling

## Worker Pattern
Follows standard RQ pattern with manual dependency instantiation:
```python
db = SessionLocal()
try:
    repo = SqlAlchemyJobRepository(db)
    service = JobService(repo)
    # ... use service
finally:
    db.close()
```

This is framework-agnostic and idiomatic for RQ/Celery workers.

## Mock Validation
Phase 4 uses 3-second sleep to simulate validation work. Real data fetching and schema validation will be implemented in Phase 5.

## Test Plan
- [x] Unit tests pass with full mocking
- [x] Integration tests skip appropriately when infrastructure unavailable
- [x] All linting/type checks pass (mypy strict mode)
- [x] Pre-commit hooks pass
- [ ] Manual end-to-end test in Docker environment (recommended before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)